### PR TITLE
fix(#45): Enable customer creation when creating a stripe checkout session

### DIFF
--- a/src/routes/api/checkout/+server.ts
+++ b/src/routes/api/checkout/+server.ts
@@ -27,6 +27,7 @@ export const POST: RequestHandler = async ({ request, cookies, locals: { safeGet
 	}));
 
 	const checkoutSession = await stripeClient.checkout.sessions.create({
+		customer_creation: 'always',
 		customer_email: userEmail,
 		line_items: lineItems,
 		mode: 'payment',


### PR DESCRIPTION
Screenshot showing a customer from our old code and one from the code updated in this PR:

<img width="213" alt="image" src="https://github.com/user-attachments/assets/37d5c0c0-c253-47ee-907f-275cb9069ff6">

The original code created a guest and allowed the user to enter whatever email they wanted. The new code forces in the user's email from the site and cannot be changed, creating a non-guest customer entity. 