### PR TITLE
feat(#74): Add token expiration for account deletion

### DIFF
--- a/supabase/migrations/20241112214000_add_token_cleanup_function.sql
+++ b/supabase/migrations/20241112214000_add_token_cleanup_function.sql
@@ -6,16 +6,29 @@ grant all privileges on all tables in schema cron to postgres;
 
 -- Create a function to delete expired tokens
 CREATE OR REPLACE FUNCTION delete_expired_tokens()
-RETURNS void LANGUAGE plpgsql AS $$
+RETURNS integer LANGUAGE plpgsql AS $$
+DECLARE
+  deletion_count integer;
+  expiry_interval interval := '24 hours'::interval;
 BEGIN
   DELETE FROM account_deletion_requests
-  WHERE requested_at < NOW() - INTERVAL '24 hours';
+  WHERE requested_at < NOW() - expiry_interval
+  RETURNING COUNT(*) INTO deletion_count;
+  RAISE NOTICE 'Deleted % expired token(s)', deletion_count;
+  RETURN deletion_count;
 END;
 $$;
 
--- Schedule the function to run every hour
-SELECT cron.schedule(
-  'delete_expired_tokens',
-  '0 * * * *',
-  'CALL delete_expired_tokens()'
-);
+DO $$
+BEGIN
+  -- Schedule the function to run every hour
+  PERFORM cron.schedule(
+    'delete_expired_tokens',
+    '0 * * * *',
+    'SELECT delete_expired_tokens()'
+  );
+EXCEPTION WHEN OTHERS THEN
+  RAISE NOTICE 'Failed to schedule token cleanup: %', SQLERRM;
+  RAISE;
+END;
+$$;

--- a/supabase/migrations/20241112214000_add_token_cleanup_function.sql
+++ b/supabase/migrations/20241112214000_add_token_cleanup_function.sql
@@ -1,0 +1,21 @@
+-- Enable the "pg_cron" extension
+create extension pg_cron with schema pg_catalog;
+
+grant usage on schema cron to postgres;
+grant all privileges on all tables in schema cron to postgres;
+
+-- Create a function to delete expired tokens
+CREATE OR REPLACE FUNCTION delete_expired_tokens()
+RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  DELETE FROM account_deletion_requests
+  WHERE requested_at < NOW() - INTERVAL '24 hours';
+END;
+$$;
+
+-- Schedule the function to run every hour
+SELECT cron.schedule(
+  'delete_expired_tokens',
+  '0 * * * *',
+  'CALL delete_expired_tokens()'
+);


### PR DESCRIPTION
Closes #74 

This enables pg_cron via SQL to prevent having to do it via the UI. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced automated cleanup of expired tokens in the database, enhancing data management.
	- Scheduled function to delete expired token requests every hour, ensuring timely maintenance.

- **Chores**
	- Enabled the "pg_cron" extension for scheduling tasks within PostgreSQL.
	- Granted necessary permissions for executing scheduled functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->